### PR TITLE
add: add a color shceme detector hook

### DIFF
--- a/hooks/usePreferredColorScheme/index.tsx
+++ b/hooks/usePreferredColorScheme/index.tsx
@@ -1,0 +1,39 @@
+/**
+ * Author: Henok Tsegaye
+ * version: 1.0.0
+ * license: MIT
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+type Props = {
+  watch?: true;
+};
+export const usePreferredColorScheme = ({
+  watch = true,
+}: Props): 'light' | 'dark' => {
+  const [colorScheme, setColorScheme] = useState<'light' | 'dark'>('light');
+
+  const setColorSchemeFromMediaQuery = useCallback(() => {
+    const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setColorScheme(isDark ? 'dark' : 'light');
+  }, []);
+
+  useEffect(() => {
+    setColorSchemeFromMediaQuery();
+    if (watch) {
+      window
+        .matchMedia('(prefers-color-scheme: dark)')
+        .addEventListener('change', setColorSchemeFromMediaQuery);
+    }
+    return () => {
+      if (watch) {
+        window
+          .matchMedia('(prefers-color-scheme: dark)')
+          .removeEventListener('change', setColorSchemeFromMediaQuery);
+      }
+    };
+  }, []);
+
+  return colorScheme;
+};

--- a/hooks/usePreferredColorScheme/readme.md
+++ b/hooks/usePreferredColorScheme/readme.md
@@ -1,0 +1,24 @@
+# usePreferredColorScheme
+
+A React hook that returns the preferred color scheme of the user.It's a wrapper around the [useMedia](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+
+## Arguments
+- watch: boolean (default true) - if true, the hook will listen to changes in the preferred color scheme and update the state accordingly
+
+## dependencies
+- Support for [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) in the browser
+
+## How to use
+```ts
+import usePreferredColorScheme from 'hooks/usePreferredColorScheme';
+
+const example = () => {
+  const colorScheme = usePreferredColorScheme();
+  return (
+    <div>
+      <p>Preferred color scheme: {colorScheme}</p>
+    </div>
+  );
+};
+```
+


### PR DESCRIPTION
Add support for Color Scheme detection hook 
Useful for 

- detecting changes when system media color scheme preference changes

## Doc

# usePreferredColorScheme

A React hook that returns the preferred color scheme of the user.It's a wrapper around the [useMedia](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)

## Arguments
- watch: boolean (default true) - if true, the hook will listen to changes in the preferred color scheme and update the state accordingly

## dependencies
- Support for [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) in the browser

## How to use
```ts
import usePreferredColorScheme from 'hooks/usePreferredColorScheme';

const example = () => {
  const colorScheme = usePreferredColorScheme();
  return (
    <div>
      <p>Preferred color scheme: {colorScheme}</p>
    </div>
  );
};
```

