### PR TITLE
Feat/add use fetch hook

### DIFF
--- a/hooks/useFetch/index.ts
+++ b/hooks/useFetch/index.ts
@@ -1,0 +1,104 @@
+import { useRef, useState } from 'react';
+
+type Props = {
+  url: string;
+  options: RequestInit;
+  cacheDuration: number;
+};
+
+type State<T> = {
+  loading: boolean | null;
+  data: T | null;
+  error: Error | null;
+};
+type ResponseType<T> = {
+  fetch: () => Promise<void>;
+  clearCache: () => void;
+  hasError: boolean;
+} & State<T>;
+
+type Cache<T> = {
+  identifier: string;
+  epochTime: number;
+  data: T;
+};
+export const useFetch = <T>({
+  url,
+  options,
+  cacheDuration,
+}: Props): ResponseType<T> => {
+  const cache = useRef<Array<Cache<T>> | null>(null);
+  const [state, setState] = useState<State<T>>({
+    loading: null,
+    error: null,
+    data: null,
+  });
+
+  const fetchData = async (
+    currentUrl?: string,
+    currentOptions?: RequestInit
+  ): Promise<void> => {
+    const currentUniqueIdentifier = getUniqueString(
+      currentUrl ?? url,
+      currentOptions ?? options
+    );
+    if (cache.current !== null) {
+      const index = cache.current.findIndex(
+        (el) => el.identifier === currentUniqueIdentifier
+      );
+      if (
+        index !== -1 &&
+        Date.now() - cache.current[index].epochTime <= cacheDuration
+      ) {
+        return;
+      }
+    }
+    try {
+      setState((prev) => ({
+        ...prev,
+        loading: true,
+      }));
+      const result = await fetch(currentUrl ?? url, currentOptions ?? options);
+      const data = result.json() as T;
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        data,
+      }));
+      cache.current = [
+        ...(cache.current ?? []),
+        {
+          identifier: currentUniqueIdentifier,
+          epochTime: Date.now(),
+          data,
+        },
+      ];
+    } catch (err: unknown) {
+      console.error(err);
+      if (err instanceof Error) {
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err as Error,
+        }));
+      }
+    }
+  };
+
+  const clearCache = (): void => {
+    cache.current = null;
+  };
+
+  return {
+    loading: state.loading,
+    error: state.error,
+    data: state.data,
+    fetch: fetchData,
+    hasError: state.error !== null,
+    clearCache,
+  };
+};
+
+const getUniqueString = (url: string, options: RequestInit): string => {
+  return `${JSON.stringify(options)}${url}`;
+};

--- a/hooks/useFetch/readme.md
+++ b/hooks/useFetch/readme.md
@@ -21,7 +21,7 @@ const example = () => {
 
     useEffect(() => {
         fetch()
-    }, [])
+    }, [fetch])
     
     if(fetching) {
         return 'loading...'

--- a/hooks/useFetch/readme.md
+++ b/hooks/useFetch/readme.md
@@ -1,0 +1,36 @@
+# useFetch
+This hook is a wrapper around the fetch function it enables you to fetch on demand using a `fetch` function returned from the hook. The hook could cache results with the given `cacheDuration` param.
+
+# Arguments
+- url: string
+- options: same as [options property for fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters)
+- cacheDuration: number
+
+# dependencies
+
+- fetch ( which is supported in all modern browsers so you shouldn't worry)
+
+# How to use
+
+```
+import { useEffect } from 'react'
+import {useFetch} from 'hooks/useFetch'
+
+const example = () => {
+    const { fetch , loading , data , error} = useFetch('https://example.com/api/getlits') 
+
+    useEffect(() => {
+        fetch()
+    }, [])
+    
+    if(fetching) {
+        return 'loading...'
+    }
+
+    if(error) {
+        return 'ops, we got error '+error.message()
+    }
+    return (<div>
+        {data?.map(el => <h1> {el.title}</h1>)}
+    </div>)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "outDir": "dist",
     "strict": true,
+    "lib": ["DOM", "ES2015"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
# useFetch
This hook is a wrapper around the fetch function it enables you to fetch on demand using a `fetch` function returned from the hook. The hook could cache results with the given `cacheDuration` param.

# Arguments
- url: string
- options: same as [options property for fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters)
- cacheDuration: number

# dependencies

- fetch ( which is supported in all modern browsers so you shouldn't worry)

# How to use

```
import { useEffect } from 'react'
import {useFetch} from 'hooks/useFetch'

const example = () => {
    const { fetch , loading , data , error} = useFetch('https://example.com/api/getlits') 

    useEffect(() => {
        fetch()
    }, [fetch])
    
    if(fetching) {
        return 'loading...'
    }

    if(error) {
        return 'ops, we got error '+error.message()
    }
    return (<div>
        {data?.map(el => <h1> {el.title}</h1>)}
    </div>)
}